### PR TITLE
Minor fixes for Emerald Kaizo-based data

### DIFF
--- a/xml/learnsets/poliwag.xml
+++ b/xml/learnsets/poliwag.xml
@@ -363,6 +363,45 @@
 		</learnset>
 		<learnset>
 			<games>
+				<game>Pokemon Emerald Kaizo</game>
+			</games>
+			<learnset_moves>
+				<learnset_move>
+					<name>Water Gun</name>
+					<level>1</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Hypnosis</name>
+					<level>7</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Bubblebeam</name>
+					<level>13</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Body Slam</name>
+					<level>19</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Water Pulse</name>
+					<level>25</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Mud Shot</name>
+					<level>31</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Ice Beam</name>
+					<level>37</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Hydro Pump</name>
+					<level>43</level>
+				</learnset_move>
+			</learnset_moves>
+		</learnset>
+		<learnset>
+			<games>
 				<game>Pokemon Sword</game>
 				<game>Pokemon Shield</game>
 			</games>

--- a/xml/learnsets/poliwhirl.xml
+++ b/xml/learnsets/poliwhirl.xml
@@ -451,8 +451,44 @@
 			</games>
 			<learnset_moves>
 				<learnset_move>
-					<name>Water gun</name>
+					<name>Bubble</name>
 					<level>1</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Hypnosis</name>
+					<level>1</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Water Gun</name>
+					<level>1</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Hypnosis</name>
+					<level>7</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Bubblebeam</name>
+					<level>13</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Hidden Power</name>
+					<level>19</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Body Slam</name>
+					<level>27</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Brick Break</name>
+					<level>35</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Mud Shot</name>
+					<level>43</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Hydro Pump</name>
+					<level>51</level>
 				</learnset_move>
 			</learnset_moves>
 		</learnset>

--- a/xml/learnsets/poliwrath.xml
+++ b/xml/learnsets/poliwrath.xml
@@ -377,8 +377,28 @@
 			</games>
 			<learnset_moves>
 				<learnset_move>
-					<name>Ice Punch</name>
+					<name>Superpower</name>
 					<level>1</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Refresh</name>
+					<level>1</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Mud Shot</name>
+					<level>1</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Hypnosis</name>
+					<level>1</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Brick Break</name>
+					<level>35</level>
+				</learnset_move>
+				<learnset_move>
+					<name>Hydro Pump</name>
+					<level>51</level>
 				</learnset_move>
 			</learnset_moves>
 		</learnset>

--- a/xml/pokemon/nosepass.xml
+++ b/xml/pokemon/nosepass.xml
@@ -188,47 +188,76 @@
 	<evolution_sets>
 		<evolution_set>
 			<games>
-				<game>Pokemon Red</game>
-				<game>Pokemon Blue</game>
-				<game>Pokemon Yellow</game>
-				<game>Pokemon Gold</game>
-				<game>Pokemon Silver</game>
-				<game>Pokemon Crystal</game>
-				<game>Pokemon Ruby</game>
-				<game>Pokemon Sapphire</game>
-				<game>Pokemon Emerald</game>
-				<game>Pokemon FireRed</game>
-				<game>Pokemon LeafGreen</game>
 				<game>Pokemon Diamond</game>
 				<game>Pokemon Pearl</game>
 				<game>Pokemon Platinum</game>
-				<game>Pokemon HeartGold</game>
-				<game>Pokemon SoulSilver</game>
+			</games>
+			<evolution_records>
+				<evolution_record>
+					<evolves_to>Probopass</evolves_to>
+                    <method>when levelled up at Mt. Coronet</method>
+				</evolution_record>
+			</evolution_records>
+		</evolution_set>
+		<evolution_set>
+			<games>
 				<game>Pokemon Black</game>
 				<game>Pokemon White</game>
 				<game>Pokemon Black 2</game>
 				<game>Pokemon White 2</game>
+			</games>
+			<evolution_records>
+				<evolution_record>
+					<evolves_to>Probopass</evolves_to>
+                    <method>when levelled up in Chargestone Cave</method>
+				</evolution_record>
+			</evolution_records>
+		</evolution_set>
+		<evolution_set>
+			<games>
 				<game>Pokemon X</game>
 				<game>Pokemon Y</game>
+			</games>
+			<evolution_records>
+				<evolution_record>
+					<evolves_to>Probopass</evolves_to>
+                    <method>when levelled up near the Electric Rock on Route 13</method>
+				</evolution_record>
+			</evolution_records>
+		</evolution_set>
+		<evolution_set>
+			<games>
 				<game>Pokemon Omega Ruby</game>
 				<game>Pokemon Alpha Sapphire</game>
+			</games>
+			<evolution_records>
+				<evolution_record>
+					<evolves_to>Probopass</evolves_to>
+                    <method>when levelled up near the Electric Rock in New Mauville</method>
+				</evolution_record>
+			</evolution_records>
+		</evolution_set>
+		<evolution_set>
+			<games>
 				<game>Pokemon Sun</game>
 				<game>Pokemon Moon</game>
+			</games>
+			<evolution_records>
+				<evolution_record>
+					<evolves_to>Probopass</evolves_to>
+                    <method>when levelled up near the Electric Rock at Vast Poni Canyon</method>
+				</evolution_record>
+			</evolution_records>
+		</evolution_set>
+		<evolution_set>
+			<games>
 				<game>Pokemon Ultra Sun</game>
 				<game>Pokemon Ultra Moon</game>
 			</games>
 			<evolution_records>
 				<evolution_record>
 					<evolves_to>Probopass</evolves_to>
-				</evolution_record>
-				<evolution_record>
-					<evolves_to>Probopass</evolves_to>
-				</evolution_record>
-				<evolution_record>
-					<evolves_to>Probopass</evolves_to>
-				</evolution_record>
-				<evolution_record>
-					<evolves_to>Probopass</evolves_to>
+                    <method>when levelled up near the Electric Rock at Blush Mountain</method>
 				</evolution_record>
 			</evolution_records>
 		</evolution_set>


### PR DESCRIPTION
Fixed Nosepass evolution information. Basically copy/pasted the Magneton data, replaced "Magnezone" with "Probopass" and deleted the SwSh entry.

Fixed Emerald Kaizo learnsets for Poliwag, Poliwhirl and Poliwrath based on the [learnsheet document from SHF](https://docs.google.com/document/d/1HTv85zFoXvuSHJgj1ZHxiXc_evGSJICpuhiI0yJ6eus/edit).

Ran validate.py and convert_to_django.py and everything passed.